### PR TITLE
Changed kobocat_base docker image repository from kobotoolbox to ahilman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kobotoolbox/kobocat_base:latest
+FROM ahilman/kobocat_base:latest
 
 ENV KOBOCAT_SRC_DIR=/srv/src/kobocat \
     BACKUPS_DIR=/srv/backups \


### PR DESCRIPTION
We can create a PR later to change docker image repository ahilman to (maybe) OpenClinica once it's created and available.

Thanks.